### PR TITLE
ci(notifications): Remove unnecessary checkouts

### DIFF
--- a/.github/workflows/notify-assignee.yaml
+++ b/.github/workflows/notify-assignee.yaml
@@ -7,8 +7,6 @@ jobs:
   notify-assignee:
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out repository.
-        uses: actions/checkout@v2.3.4
       - name: Send Slack notification assigning pull request.
         uses: ScribeMD/slack-templates@0.1.0
         with:

--- a/.github/workflows/notify-reviewers.yaml
+++ b/.github/workflows/notify-reviewers.yaml
@@ -7,8 +7,6 @@ jobs:
   notify-reviewers:
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out repository.
-        uses: actions/checkout@v2.3.4
       - name: Send Slack notification requesting code review.
         uses: ScribeMD/slack-templates@0.1.0
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.9
       - name: Install Poetry.
         run: pip install poetry==1.2.0a2
-      - name: Install rootless Docker.
+      - name: Use Docker in rootless mode.
         uses: ./
       - name: Run pre-commit hooks.
         uses: pre-commit/action@v2.0.3


### PR DESCRIPTION
There is no need to check out the current repository in a GitHub Action if no files in the repository are used in the workflow. Our Slack notification workflows are handled entirely by slack-templates.

- ci(test): Clarify name of self-test step. This GitHub Action does install rootless Docker, but more importantly it also configures Docker to use rootless mode.