### PR TITLE
docs(README): Specify specific version in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ docker info --format "{{ .ClientInfo.Context }}"
 
 ```yaml
 - name: Use Docker in rootless mode.
-  uses: ScribeMD/rootless-docker@0
+  uses: ScribeMD/rootless-docker@0.1.1
 ```
 
 ## Supported Runners

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "poetry.core.masonry.api"
   [tool.commitizen]
   version = "0.1.1"
   version_files = [
-    "pyproject.toml:version"
+    "pyproject.toml:version",
+    "README.md:rootless-docker@"
   ]
 
   [tool.poetry]


### PR DESCRIPTION
We do not tag the major version, so users must specify a specific version of the action to use.

Fixes #11.