### PR TITLE
chore(Node.js): Pin version via asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
+nodejs 16.14.2
 python 3.9.7
 poetry 1.1.13


### PR DESCRIPTION
We depend on Node.js, because the MegaLinter pre-commit hooks use npx, which ships with npm, which ships with Node.js.