### PR TITLE
ci(pre-commit): Configure default hook types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,9 @@
+default_install_hook_types:
+  - commit-msg
+  - post-checkout
+  - pre-commit
+  - pre-merge-commit
+  - pre-push
 default_language_version:
   python: python3.9.7
 default_stages:


### PR DESCRIPTION
Reduce the number of flags the developer must specify to set up pre-commit.