### PR TITLE
ci(Test): Simplify via pre-commit-action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,31 +13,10 @@ jobs:
     steps:
       - name: Check out repository.
         uses: actions/checkout@v3.0.2
-      - name: Install asdf-managed tools based on .tool-versions.
-        uses: asdf-vm/actions/install@v1.1.0
-        with:
-          asdf_branch: v0.10.0
-      - name: Add Poetry and its dependencies to PATH.
-        run: |
-          for version in ~/.asdf/installs/poetry/*; do
-            echo "$version/bin" >> "$GITHUB_PATH"
-          done
-          echo "${{ github.workspace }}"/.venv/bin >> "$GITHUB_PATH"
-      - name: Cache Poetry dependencies.
-        uses: actions/cache@v3.0.2
-        with:
-          path: .venv
-          key: poetry-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
-      - name: Install Poetry dependencies.
-        run: poetry install
       - name: Use Docker in rootless mode.
         uses: ./
-      - name: Run pre-push hooks.
-        uses: pre-commit/action@v2.0.3
-        env:
-          SKIP: no-commit-to-branch
-        with:
-          extra_args: "--all-files --hook-stage push"
+      - name: Run pre-commit hooks.
+        uses: ScribeMD/pre-commit-action@0.1.5
       - name: Send Slack notification with job status.
         if: always()
         uses: ScribeMD/slack-templates@0.2.3


### PR DESCRIPTION
Many steps of the Test workflow have been consolidated into `pre-commit-action` to reduce duplication across repositories. Continue to self-test action at current ref.