### PR TITLE
docs(contributing): Remove `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-# Contributing Guide
-
-See [CONTRIBUTING.md of ScribeMD/slack-templates](https://github.com/ScribeMD/slack-templates/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Run Docker in Rootless Mode to Prevent Permission Errors
 - [rootless-docker](#rootless-docker)
   - [Usage](#usage)
   - [Supported Runners](#supported-runners)
-  - [Contributing](#contributing)
   - [Changelog](#changelog)
 
 <!--TOC-->
@@ -57,10 +56,6 @@ docker info --format "{{ .ClientInfo.Context }}"
 - May work on future versions of Linux
 - Definitely doesn't work on Windows or macOS since Docker only offers rootless
   mode on Linux
-
-## Contributing
-
-Please refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Changelog
 


### PR DESCRIPTION
It has been moved from slack-templates to the special .github repository. All repositories without their own contributing guide default to that shared guide.