### PR TITLE
docs(README): Format `CHANGELOG.md` as code

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ docker info --format "{{ .ClientInfo.Context }}"
 
 ## Changelog
 
-Please refer to [CHANGELOG.md](CHANGELOG.md).
+Please refer to [`CHANGELOG.md`](CHANGELOG.md).


### PR DESCRIPTION
Style file paths as code for consistency with our contributing guide and to emphasize that they are to be interpreted verbatim.