### PR TITLE
ci(GitHub-Actions): Grant minimum necessary scopes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write # for pre-commit-action
     steps:
       - name: Check out repository.
         uses: actions/checkout@v3.0.2


### PR DESCRIPTION
pre-commit-action requires the `contents:write` scope to bump the project version via Commitizen. Granting this specific permission also has the effect of reducing the scope of all unspecified permissions from read to none for pull requests from Dependabot and forks and from write to none for workflows triggered by anything else (even re-runs of Dependabot pull requests). Since this repository is public, most of its data can be read without additional permissions though.