### PR TITLE
chore(MegaLinter): Upgrade from v5.14.0 to v5.15.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
 
   ## Python, Polyglot, Git, pre-commit
   - repo: https://github.com/ScribeMD/pre-commit-hooks
-    rev: 0.6.2
+    rev: 0.7.0
     hooks:
       - id: no-merge-commits
       - id: asdf-install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: poetry-install
       - id: pre-commit-install
       - id: megalinter
-        args: &megalinter-args [--flavor, documentation, --release, v5.14.0]
+        args: &megalinter-args [--flavor, documentation, --release, v5.15.0]
       - id: megalinter-all
         args: *megalinter-args
 


### PR DESCRIPTION
Upgrade all pre-commit hooks to latest versions.

ScribeMD/pre-commit-hooks 0.6.2 --> 0.7.0