### PR TITLE
fix(action): Stop hard-coding `XDG_RUNTIME_DIR`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -55,6 +55,4 @@ runs:
 
         (PATH="/home/runner/bin:/sbin:/usr/sbin:$PATH" dockerd-rootless.sh &) |&
         awaitDockerd
-      env:
-        XDG_RUNTIME_DIR: /home/runner/.docker/run
       shell: bash


### PR DESCRIPTION
GitHub Actions made an unannounced change, setting `XDG_RUNTIME_DIR` to `/run/user/1001` and removing `/home/runner/.docker/run`, which we used to set `XDG_RUNTIME_DIR` to. This action began failing with the error message "`XDG_RUNTIME_DIR` needs to be set and writable," because `/home/runner/.docker/run` no longer existed.