### PR TITLE
fix(action): Set recommended environment variables

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,12 @@ runs:
       shell: bash
     - name: Use rootless Docker.
       if: steps.rootless-docker.outputs.in-use != 'true'
-      run: docker context use rootless
+      run: |
+        if [[ -z $XDG_RUNTIME_DIR ]]; then
+          echo XDG_RUNTIME_DIR=~/.docker/run >>"$GITHUB_ENV"
+        fi
+        echo ~/bin >>"$GITHUB_PATH"
+        docker context use rootless
       shell: bash
     - name: Start rootless Docker daemon, and wait until it's listening.
       if: steps.rootless-docker.outputs.in-use != 'true'
@@ -53,6 +58,6 @@ runs:
           return 1
         }
 
-        (PATH="/home/runner/bin:/sbin:/usr/sbin:$PATH" dockerd-rootless.sh &) |&
+        (PATH="/sbin:/usr/sbin:$PATH" dockerd-rootless.sh &) |&
         awaitDockerd
       shell: bash


### PR DESCRIPTION
The rootless Docker installation script suggests setting `XDG_RUNTIME_DIR` to `~/.docker/run` when it isn't already set. Doing so prevents flakiness caused by the fact that some runners set `XDG_RUNTIME_DIR` to `/run/user/1001` but don't have `~/.docker/run`, while some don't set it but do have `~/.docker/run`. Also follow the script's suggestion of prepending `~/bin` to the `PATH`. Disregard the suggestion to set `DOCKER_HOST` to `unix://$XDG_RUNTIME_DIR/docker.sock` since we already achieve the same effect by setting the context to rootless.