### PR TITLE
fix(action): Forward rootful Docker socket

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -57,7 +57,7 @@ runs:
           sh)"
         echo "$install_script_output"
         docker context use rootless
-        if !grep --quiet "$success_sentinel" <<<"$install_script_output"; then
+        if ! grep --quiet "$success_sentinel" <<<"$install_script_output"; then
           (PATH="/sbin:/usr/sbin:$PATH" dockerd-rootless.sh &) |&
           awaitDockerd
         fi

--- a/action.yaml
+++ b/action.yaml
@@ -61,6 +61,7 @@ runs:
           (PATH="/sbin:/usr/sbin:$PATH" dockerd-rootless.sh &) |&
           awaitDockerd
         fi
+        sudo systemctl start docker.service docker.socket
       env:
         FORCE_ROOTLESS_INSTALL: "1"
       shell: bash


### PR DESCRIPTION
The GitHub Actions runner hard-codes the Docker socket to `unix:///var/run/docker.sock`, so all Docker actions that run after this one fail attempting to connect to the stopped rootful Docker daemon. Start the rootful Docker daemon back up to work around this issue.

Correct syntax of Bash negation.