### PR TITLE
fix(action): Proxy rootful/rootless Docker sockets

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,1 +1,2 @@
 Laven
+proxyd

--- a/action.yaml
+++ b/action.yaml
@@ -28,17 +28,14 @@ runs:
       if: steps.rootless-docker.outputs.in-use != 'true'
       run: sudo systemctl stop docker.service docker.socket
       shell: bash
-    - name: Set environment variables recommended by rootless Docker install script.
-      if: steps.rootless-docker.outputs.installed != 'true'
-      run: |
-        if [[ -z $XDG_RUNTIME_DIR ]]; then
-          echo XDG_RUNTIME_DIR=~/.docker/run >>"$GITHUB_ENV"
-        fi
-        echo ~/bin >>"$GITHUB_PATH"
-      shell: bash
     - name: Install rootless Docker, start daemon, and wait until it's listening.
       if: steps.rootless-docker.outputs.installed != 'true'
       run: |
+        echo ~/bin >>"$GITHUB_PATH"
+        if [[ -z $XDG_RUNTIME_DIR ]]; then
+          XDG_RUNTIME_DIR=~/.docker/run
+          echo XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" >>"$GITHUB_ENV"
+        fi
         success_sentinel="API listen on $XDG_RUNTIME_DIR/docker.sock"
         function awaitDockerd() {
           while IFS= read -r -t 60 line; do

--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,7 @@ runs:
         echo "::set-output name=installed::$installed"
         echo "::set-output name=in-use::$in_use"
       shell: bash
-    - name: Stop Docker daemon.
+    - name: Stop rootful Docker daemon.
       if: steps.rootless-docker.outputs.in-use != 'true'
       run: sudo systemctl stop docker.service docker.socket
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -26,7 +26,7 @@ runs:
       shell: bash
     - name: Stop rootful Docker daemon.
       if: steps.rootless-docker.outputs.in-use != 'true'
-      run: sudo systemctl stop docker.service docker.socket
+      run: sudo systemctl stop docker.service
       shell: bash
     - name: Install rootless Docker, start daemon, and wait until it's listening.
       if: steps.rootless-docker.outputs.installed != 'true'
@@ -58,7 +58,18 @@ runs:
           (PATH="/sbin:/usr/sbin:$PATH" dockerd-rootless.sh &) |&
           awaitDockerd
         fi
-        sudo systemctl start docker.service docker.socket
       env:
         FORCE_ROOTLESS_INSTALL: "1"
+      shell: bash
+    - name: Proxy bidirectionally between rootful and rootless Docker sockets.
+      if: steps.rootless-docker.outputs.in-use != 'true'
+      run: >
+        sudo systemd-run
+        --unit=docker-proxy.service
+        --description="Bidirectional proxy between rootful and rootless Docker sockets"
+        --service-type=exec
+        --property=Requires=docker.socket
+        --property=PrivateNetwork=true
+        --property=PrivateTmp=true
+        /lib/systemd/systemd-socket-proxyd "$XDG_RUNTIME_DIR/docker.sock"
       shell: bash


### PR DESCRIPTION
The GitHub Actions runner hard-codes the Docker socket to `unix:///var/run/docker.sock`. It is no longer possible to reliably run the rootful and rootless Docker daemons concurrently now that they each check that they are the only daemon running. Hence, proxy bidirectionally between the rootful and rootless (`unix://$XDG_RUNTIME_DIR/docker.sock`) Docker sockets rather than attempt to start the rootful Docker daemon back up. Don't close the rootful Docker socket so that it can be proxied.

Don't set environment variables early. The rootless Docker install script recommends setting some environment variables after it's run. Setting `XDG_RUNTIME_DIR` in particular before the script has run prevents it from automatically creating `~/.docker/run` when `XDG_RUNTIME_DIR` is unset. Hence, wait until the script has run to set these environment variables. While the commands to set these environment variables still take place before the install script is run, they will not be sourced by the GitHub Actions runner until the subsequent workflow step runs.

Make a workflow step name more descriptive. Clarify that the step stops the rootful, not rootless, Docker daemon.