### PR TITLE
fix(action): Only run `dockerd-rootless.sh` if told

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -36,11 +36,10 @@ runs:
           XDG_RUNTIME_DIR=~/.docker/run
           echo XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" >>"$GITHUB_ENV"
         fi
-        success_sentinel="API listen on $XDG_RUNTIME_DIR/docker.sock"
         function awaitDockerd() {
           while IFS= read -r -t 60 line; do
             echo "$line"
-            [[ "$line" = *"$success_sentinel"* ]] && return
+            [[ "$line" = *"API listen on $XDG_RUNTIME_DIR/docker.sock"* ]] && return
           done
           echo "Timed out waiting for Docker daemon to listen." >&2
           return 1
@@ -54,7 +53,7 @@ runs:
           sh)"
         echo "$install_script_output"
         docker context use rootless
-        if ! grep --quiet "$success_sentinel" <<<"$install_script_output"; then
+        if grep --quiet "systemd not detected, dockerd-rootless.sh needs to be started manually" <<<"$install_script_output"; then
           (PATH="/sbin:/usr/sbin:$PATH" dockerd-rootless.sh &) |&
           awaitDockerd
         fi


### PR DESCRIPTION
GitHub Actions made an unannounced change impacting how we determine whether the rootless Docker install script started the Docker daemon. Previously, `"API listen on $XDG_RUNTIME_DIR/docker.sock"` was present in the script's output if the Docker daemon was started, but this is no longer guaranteed. Running `dockerd-rootless.sh` when the Docker daemon has already been started results in an error, so only run it when the install script outputs an explicit instruction to do so.