### PR TITLE
ci(GitHub-Actions): Grant minimum necessary scopes

### DIFF
--- a/.github/workflows/notify-assignee.yaml
+++ b/.github/workflows/notify-assignee.yaml
@@ -7,6 +7,8 @@ jobs:
   notify-assignee:
     name: Notify Assignee
     uses: ScribeMD/slack-templates/.github/workflows/notify-assignee.yaml@0.6.3
+    permissions:
+      contents: read
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_ASSIGN_CHANNEL_ID: ${{ secrets.SLACK_ASSIGN_CHANNEL_ID }}

--- a/.github/workflows/notify-reviewers.yaml
+++ b/.github/workflows/notify-reviewers.yaml
@@ -7,6 +7,8 @@ jobs:
   notify-reviewers:
     name: Notify Reviewers
     uses: ScribeMD/slack-templates/.github/workflows/notify-reviewers.yaml@0.6.3
+    permissions:
+      contents: read
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}


### PR DESCRIPTION
Grant callable workflows the permissions they require. The Notify Assignee and Notify Reviewers workflows require the `contents:read` scope. [actions/checkout](https://github.com/actions/checkout) uses the `contents:read` scope to check out the calling repository. Granting this specific permission also has the effect of reducing the scope of all unspecified permissions from read to none. Since this repository is public, most of its data can be read without additional permissions, but the `contents:read` scope is needed in the callable workflows when the calling repository is private. Callable workflows can only be called when granted the permissions they require.