### PR TITLE
docs(VSCode): Recommend Python extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
     "ms-azuretools.vscode-docker",
+    "ms-python.python",
     "ms-vscode-remote.remote-containers",
     "redhat.vscode-yaml",
     "streetsidesoftware.code-spell-checker"


### PR DESCRIPTION
The Python extension automatically activates the Poetry shell. We use Poetry to install pre-commit and Commitizen.