### PR TITLE
chore(MegaLinter): Upgrade from v6.12.0 to v6.13.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
 
   ## Python, Polyglot, Git, pre-commit
   - repo: https://github.com/ScribeMD/pre-commit-hooks
-    rev: 0.14.0
+    rev: 0.15.0
     hooks:
       - id: no-merge-commits
       - id: asdf-install
@@ -26,7 +26,7 @@ repos:
       - id: poetry-install
       - id: pre-commit-install
       - id: megalinter-incremental
-        args: &megalinter-args [--flavor, documentation, --release, v6.12.0]
+        args: &megalinter-args [--flavor, documentation, --release, v6.13.0]
       - id: megalinter-full
         args: *megalinter-args
 


### PR DESCRIPTION
Upgrade ScribeMD/pre-commit-hooks from 0.14.0 to 0.15.0 for corresponding mega-linter-runner upgrade.