### PR TITLE
fix(action): Print get.docker.com error messages

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -47,7 +47,7 @@ runs:
 
         install_script_output="$(
           curl \
-          --fail \
+          --fail-with-body \
           --silent \
           --show-error \
           --location https://get.docker.com/rootless |


### PR DESCRIPTION
Replace `--fail` with `--fail-with-body` in cURL invocation that downloads the rootless Docker install script. This causes cURL to display any error message it may receive from the server, which is often helpful context to have when debugging.