### PR TITLE
chore(Renovate): Bump config from 0.4.1 to 0.5.1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ScribeMD/.github#0.4.1"]
+  "extends": ["github>ScribeMD/.github#0.5.1"]
 }


### PR DESCRIPTION
Pull in removal of post-upgrade options and `platformCommit`, allowing Forking Renovate to run. Pull in narrowing of called workflow regex, addressing Renovate warning.