### PR TITLE
ci(workflow): Hasten checkout with blobless clones

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4.1.0
         with:
           fetch-depth: 0
+          filter: blob:none
       - name: Use Docker in rootless mode.
         uses: ./
       - name: Run pre-commit hooks.


### PR DESCRIPTION
In v4.1.0, actions/checkout recently introduced support for Git's partial clones. Partial clones are smaller than full clones (`fetch-depth: 0`), because they don't clone historical blobs and/or trees. In partial clones, Git operations will typically fetch data that isn't available locally as needed. Hence, prefer blobless clones, the partial clones that give the best performance overall, to full clones.