### PR TITLE
Add AppArmor 4 config

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,1 +1,4 @@
 Laven
+rootlesskit
+tunables
+userns

--- a/action.yaml
+++ b/action.yaml
@@ -44,8 +44,10 @@ runs:
         cat <<EOF > ~/${filename}
         abi <abi/${ABI4_VERSION}>,
         include <tunables/global>
+
         "$HOME/bin/rootlesskit" flags=(unconfined) {
           userns,
+
           include if exists <local/${filename}>
         }
         EOF

--- a/action.yaml
+++ b/action.yaml
@@ -28,6 +28,30 @@ runs:
       if: steps.rootless-docker.outputs.IN_USE != 'true'
       run: sudo systemctl stop docker.service
       shell: bash
+    - name: Check AppArmor version
+      id: apparmor
+      run: |
+        abi4_version="$(find /etc/apparmor.d/abi -maxdepth 1 -name '4.*' -printf '%f\n' | sort -nr | head -1)"
+        echo "$abi4_version"
+        echo "ABI4_VERSION=$abi4_version" >>"$GITHUB_OUTPUT"
+      shell: bash
+    - name: Configure AppArmor
+      if: steps.rootless-docker.outputs.INSTALLED != 'true' && steps.apparmor.outputs.ABI4_VERSION != ''
+      env:
+        ABI4_VERSION: ${{ steps.apparmor.outputs.ABI4_VERSION }}
+      run: |
+        filename=$(echo $HOME/bin/rootlesskit | sed -e s@^/@@ -e s@/@.@g)
+        cat <<EOF > ~/${filename}
+        abi <abi/${ABI4_VERSION}>,
+        include <tunables/global>
+        "$HOME/bin/rootlesskit" flags=(unconfined) {
+          userns,
+          include if exists <local/${filename}>
+        }
+        EOF
+        sudo mv ~/${filename} /etc/apparmor.d/${filename}
+        sudo systemctl restart apparmor.service
+      shell: bash
     - name: Install rootless Docker, start daemon, and wait until it's listening.
       if: steps.rootless-docker.outputs.INSTALLED != 'true'
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -32,7 +32,6 @@ runs:
       id: apparmor
       run: |
         abi4_version="$(find /etc/apparmor.d/abi -maxdepth 1 -name '4.*' -printf '%f\n' | sort -nr | head -1)"
-        echo "$abi4_version"
         echo "ABI4_VERSION=$abi4_version" >>"$GITHUB_OUTPUT"
       shell: bash
     - name: Configure AppArmor


### PR DESCRIPTION
## What are these changes?
This change resolves #401 by adding an AppArmor profile for rootlesskit on runners using AppArmor 4.

## Why are these changes being made?
These changes are required to run ScribeMD/rootless-docker on `ubuntu-24.04`.

## Notes:
* Added some terms to the dictionary to make CSpell happy.
* I was getting errors when trying to apply this config on `ubuntu-22.04` (which uses AppArmor 3), so I've configured this change to only apply the config on platforms using AppArmor 4 (`steps.apparmor.outputs.ABI4_VERSION != ''`).
* Tests for this change are in #403.